### PR TITLE
Disable source maps in Vite configuration for production build

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     assetsDir: "static",
     cssMinify: true,
     cssCodeSplit: true,
-    sourcemap: true,
+    sourcemap: false,
     minify: true,
     ssrManifest: true,
     modulePreload: true,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -16,7 +16,7 @@
       "noUnusedLocals": true, // this is for set the no unused locals
       "noUnusedParameters": true, // this is for set the no unused parameters
       "skipLibCheck": true, // this is for set the skip lib check
-      "sourceMap": true, // this is for set the source map
+      "sourceMap": false, // this is for set the source map
   },
   "include": [
       "./source/**/*"


### PR DESCRIPTION
This pull request includes changes to the configuration settings for both the client and server. The most important changes involve disabling source maps in both configurations.

Configuration updates:

* [`client/vite.config.ts`](diffhunk://#diff-ba54b61c10b48d1e2509d8ad3e5a1b0f0cbf878692a21dca8ed3e880850341deL21-R21): Changed the `sourcemap` option from `true` to `false` to disable source maps in the client configuration.
* [`server/tsconfig.json`](diffhunk://#diff-f3eab147f9c67d8aeb9f4f641a6b199d8b9eebae738083ea2f9a4a79aaca0175L19-R19): Changed the `sourceMap` option from `true` to `false` to disable source maps in the server configuration.